### PR TITLE
Link HTML object to the wiki file page of the PDF file

### DIFF
--- a/extensions/PDFEmbed/PDFEmbed.hooks.php
+++ b/extensions/PDFEmbed/PDFEmbed.hooks.php
@@ -73,9 +73,9 @@ class PDFEmbed {
 	}
 
 	/**
-	 * Returns a standard error message.
+	 * Returns a HTML object as string.
 	 *
-	 * @access	public
+	 * @access	private
 	 * @param	object	File object.
 	 * @param	integer	Width of the object.
 	 * @param	integer	Height of the object.
@@ -88,7 +88,7 @@ class PDFEmbed {
 	/**
 	 * Returns a standard error message.
 	 *
-	 * @access	public
+	 * @access	private
 	 * @param	string	Error message key to display.
 	 * @return	string	HTML error message.
 	 */


### PR DESCRIPTION
Hack to link the HTML object to the wiki file page of the embedded PDF file. Like you can click on an included image (with `[[File:my_image.png]]`) to get to the wiki file page of the image to get more information (like author, license) about this file.
